### PR TITLE
Added deprecation warning for Puppet >= 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ This module provides management of Ruby gems for Puppet Enterprise.
     }
 
 This uses puppet gem as a parent and simply alters the gem path to /opt/puppet/bin/gem.
+
+## Deprecation for Puppet >= 4.0
+
+As of Puppet 4.0, this module has been deprecated. Please use the puppet_gem provider instead.

--- a/lib/puppet/provider/package/pe_gem.rb
+++ b/lib/puppet/provider/package/pe_gem.rb
@@ -12,4 +12,12 @@ Puppet::Type.type(:package).provide :pe_gem, :parent => :gem do
   has_feature :versionable, :install_options
 
   commands :gemcmd => "/opt/puppet/bin/gem"
+
+  def self.instances
+    if Puppet[:version].to_f >= 4.0
+      warn "DEPRECATION: As of Puppet 4.0, the pe_gem provider for the package resource has been deprecated. Please use the puppet_gem provider instead."
+    end
+
+    super
+  end
 end


### PR DESCRIPTION
This is untested as I can't seem to be able to obtain a shallow gravey (PE4) release with Puppet 4 installed.