### PR TITLE
(MODULES-2848) Reference puppet_gem better

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ This uses puppet gem as a parent and simply alters the gem path to /opt/puppet/b
 
 ## Deprecation for Puppet >= 4.0
 
-As of Puppet 4.0, this module has been deprecated. Please use the puppet_gem provider instead.
+As of Puppet 4.0, this module has been deprecated. Please use Puppet 4.0's built-in [puppet_gem](http://docs.puppetlabs.com/references/4.0.0/type.html#package-provider-puppet_gem) provider instead.


### PR DESCRIPTION
pe_gem is supplanted by puppet_gem in Puppet 4.0. However, a user's
first inclination might be that puppet_gem is another module, and so
waste time looking for it on the Forge and getting confused. This commit
updates the README to explicitly state that it's a built-in component of
Puppet 4.0 and provide a direct link to the provider description in the
docs.