### PR TITLE
(PUP-5282) fix pe_gem provider to work on windows

### DIFF
--- a/lib/puppet/provider/package/pe_gem.rb
+++ b/lib/puppet/provider/package/pe_gem.rb
@@ -10,8 +10,11 @@ Puppet::Type.type(:package).provide :pe_gem, :parent => :gem do
     repositories."
 
   has_feature :versionable, :install_options
-
-  commands :gemcmd => "/opt/puppet/bin/gem"
+  if Facter.value(:kernel) == 'windows'
+    commands :gemcmd => "gem"
+  else
+    commands :gemcmd => "/opt/puppet/bin/gem"
+  end
 
   def self.instances
     if Puppet[:version].to_f >= 4.0
@@ -19,5 +22,45 @@ Puppet::Type.type(:package).provide :pe_gem, :parent => :gem do
     end
 
     super
+  end
+
+  def install(useversion = true)
+    command = [command(:gemcmd), "install"]
+    command << "-v" << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
+
+    if source = resource[:source]
+      begin
+        uri = URI.parse(source)
+      rescue => detail
+        self.fail Puppet::Error, "Invalid source '#{uri}': #{detail}", detail
+      end
+
+      case uri.scheme
+        when nil
+          # no URI scheme => interpret the source as a local file
+          command << source
+        when /file/i
+          command << uri.path
+        when 'puppet'
+          # we don't support puppet:// URLs (yet)
+          raise Puppet::Error.new("puppet:// URLs are not supported as gem sources")
+        else
+          # check whether it's an absolute file path to help Windows out
+          if Puppet::Util.absolute_path?(source)
+            command << source
+          else
+            # interpret it as a gem repository
+            command << "--source" << "#{source}" << resource[:name]
+          end
+      end
+    else
+      command << "--no-rdoc" << "--no-ri" << resource[:name]
+    end
+
+    command += install_options if resource[:install_options]
+
+    output = execute(command)
+    # Apparently some stupid gem versions don't exit non-0 on failure
+    self.fail "Could not install: #{output.chomp}" if output.include?("ERROR")
   end
 end


### PR DESCRIPTION
[PUP-5282](https://tickets.puppetlabs.com/browse/PUP-5282) fixed an issue that causes the gem command to not work when using the source option and local file paths on windows.

The upstream fix was applied here:  https://github.com/puppetlabs/puppet/blob/c41918d8cfae0e16fa3eb709743fbe64bbbf4efa/lib/puppet/provider/package/gem.rb#L93

I took that code and put it inside the pe_gem provider which in turns overrides the default gem install method and uses the newer code.  This allows everyone using PE to automatically get the upstream fix only available in FOSS 4.3.1 when using pe_gem provider. 

In order to make this work for windows I additionally added a gem path specific for windows. This previously did not exist because windows FOSS and PE have always have the same gem binary path where as non-windows is different.


